### PR TITLE
Fixed Dependency in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ ADD https://bootstrap.pypa.io/get-pip.py get-pip.py
 RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     apt update && \
     apt install -y python3.7 && \
+    apt install -y python3.7-distutils && \
     python3.7 get-pip.py && \
     rm -rf /root/get-pip.py && \
     apt install libpython3.7


### PR DESCRIPTION
It was missing python3.7-distutils which caused this error: `ModuleNotFoundError: No module named 'distutils.cmd'`